### PR TITLE
Hiding Password

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -28,7 +28,7 @@ export default function LoginPage() {
     try {
       setLoading(true);
       console.log("CheckPoint 1 Login");
-      console.log("User : ", user);
+      console.log("User : ", user.email);
 
       const res = await axios.post("/api/users/login", user);
       if (res.data.error) {


### PR DESCRIPTION
Entire Details of the users were being logged in the console of the Browser which was a problem, as in Production grade this is a major blunder.

The fix was simple either make the field so as it prints only email and nothing else or remove it completely.

I choose first option . Peace !!